### PR TITLE
Normalize Qt dialog acceptance comparisons

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,100 +1,60 @@
 # Project Status
 
-**Last Updated:** November 5, 2025  
-**Current Phase:** Foundation (Week 1)  
-**Version:** 0.1.0-dev  
+**Last Updated:** November 9, 2025
+**Current Phase:** Matching Engine Preparation (Week 4)
+**Version:** 0.1.0
 **Project Lead:** AlobarQuest
 
-## Current Milestone: Foundation
+## Current Milestone: Matching Engine Prep (Week 4)
 
-**Goal:** Establish project structure, documentation, and database foundation
-
-**Target Completion:** Week 1
+**Goal:** Stand up the job description matching pipeline that will rank bullet points with TF-IDF scoring and tag heuristics.
+**Target Completion:** Week 4 (In Progress)
 
 ## Completed Items ✅
 
-### Project Setup
-- [x] GitHub repository created
-- [x] MIT License added
-- [x] Repository structure established
-- [x] .gitignore configured
-- [x] README.md created
-- [x] requirements.txt and requirements-dev.txt defined
-- [x] Initial commit pushed to GitHub
-- [x] Main and develop branches created
+### Week 1 – Foundation
+- [x] Repository, licensing, and Git Flow structure established (`README.md`, `.gitignore`, `LICENSE`).
+- [x] Core documentation suite drafted (project plan, architecture, setup, ADRs in `docs/`).
+- [x] SQLAlchemy base, models, and Alembic migration created to capture the full schema (`src/adaptive_resume/models/`, `alembic/versions/d8eaf3acb5a7_initial_schema_with_all_models.py`).
+- [x] Pytest and tooling configuration defined in `pyproject.toml` with shared fixtures in `tests/conftest.py`.
 
-### Documentation
-- [x] PROJECT_PLAN.md - Master implementation plan
-- [x] SETUP.md - Development environment setup guide
-- [x] AI_SESSION_GUIDE.md - AI assistant onboarding
-- [x] STATUS.md - Project status tracking (this file)
-- [x] All 5 Architecture Decision Records
-- [x] **ARCHITECTURE.md** - System architecture overview
-- [x] **DATABASE_SCHEMA.md** - Complete database documentation with ERD
-- [x] **MODELS_IMPLEMENTATION.md** - Model implementation summary
+### Week 2 – Core Data Management
+- [x] Profile and job domain services with validation and CRUD workflows (`src/adaptive_resume/services/profile_service.py`, `src/adaptive_resume/services/job_service.py`).
+- [x] Skill, education, and certification services implementing ordering and input validation (`src/adaptive_resume/services/skill_service.py`, `src/adaptive_resume/services/education_service.py`, `src/adaptive_resume/services/certification_service.py`).
+- [x] Unit coverage for all service layers, including negative cases and reordering logic (`tests/unit/test_profile_service.py`, `tests/unit/test_job_service.py`, `tests/unit/test_skill_service.py`, `tests/unit/test_education_service.py`, `tests/unit/test_certification_service.py`).
+- [x] Model-focused tests verifying relationships and helpers (`tests/unit/test_profile.py`, `tests/unit/test_job.py`, `tests/unit/test_bullet_point.py`).
 
-### Code Foundation ✅
-- [x] **pyproject.toml** - Package configuration
-- [x] **SQLAlchemy base model setup**
-- [x] **All database models implemented (14 tables)**
-  - [x] base.py - Database configuration
-  - [x] profile.py - User profile
-  - [x] job.py - Employment history
-  - [x] bullet_point.py - Achievements
-  - [x] tag.py - Tags and BulletTag junction
-  - [x] skill.py - Skills with proficiency
-  - [x] education.py - Academic credentials
-  - [x] certification.py - Professional certifications
-  - [x] job_application.py - Application tracking
-  - [x] generated_resume.py - Document history
-  - [x] templates.py - Resume templates and cover letter sections
-  - [x] __init__.py - Package exports
-  - [x] README.md - Models documentation
-- [x] **test_models.py** - Model verification script
-- [x] **Models tested and working** ✅
-- [x] **Alembic migration system configured** ✨ NEW
-- [x] **Initial migration created** ✨ NEW
-- [x] **Database initialized successfully** ✨ NEW
+### Week 3 – Basic GUI
+- [x] PyQt6 main window coordinating profile/job navigation, toolbar actions, and status feedback (`src/adaptive_resume/gui/main_window.py`).
+- [x] Profile and job dialogs supporting CRUD operations with inline bullet point management (`src/adaptive_resume/gui/dialogs/profile_dialog.py`, `src/adaptive_resume/gui/dialogs/job_dialog.py`).
+- [x] Skills and education panels backed by service lookups plus a skills summary view for quick aggregation (`src/adaptive_resume/gui/widgets/skills_panel.py`, `src/adaptive_resume/gui/widgets/education_panel.py`, `src/adaptive_resume/gui/views/skills_summary_view.py`).
+- [x] Job-focused view wiring job/bullet selections and placeholder application view for future expansion (`src/adaptive_resume/gui/views/jobs_view.py`, `src/adaptive_resume/gui/views/applications_view.py`).
+- [x] GUI smoke tests instantiating the main window and dialogs (`tests/unit/test_gui_main_window.py`, `tests/unit/test_gui_dialogs.py`).
 
-### Git Configuration
-- [x] Main branch created
-- [x] Develop branch created
-- [x] Git Flow strategy documented
-- [x] User configured (devon.watkins@gmail.com)
+### Tooling & Ops
+- [x] Optional dependency groups declared for GUI, PDF, and NLP extras (`pyproject.toml`).
+- [x] Git user and branching strategy confirmed.
 
 ## In Progress 🚧
 
-### Next Priority
-- [ ] Set up pytest structure
-- [ ] Create unit tests for models
-- [ ] Commit all progress to Git
-- [ ] Tag v0.1.0 (Foundation Complete)
+- [ ] Matching engine service combining TF-IDF scoring with tag heuristics.
+- [ ] Resume assembly helpers to feed GUI previews and PDF rendering.
+- [ ] Analytics over skills/education data to support future matching weights.
+- [ ] Broader GUI interaction tests (multi-dialog flows, bulk updates) ahead of matching integration.
 
-## Not Started
+## Next Steps ▶️
 
-### Week 1 Remaining (Almost Done!)
-- [ ] pytest unit test structure
-- [ ] Unit tests for models (target: 90%+ coverage)
-- [ ] Git commit of all Week 1 work
-- [ ] Tag v0.1.0 - Foundation Complete
+1. Implement the Week 4 matching engine pipeline (description ingestion, keyword extraction, scoring service) with accompanying unit tests.
+2. Extend orchestration utilities so the GUI preview panes can consume assembled resume data.
+3. Document GUI architecture decisions (signal/slot wiring, widget composition) and expand user help content.
+4. Begin the PDF groundwork by defining resume template contracts and placeholder render hooks.
 
-### Week 2: Core Data Management
-- [ ] Profile CRUD operations
-- [ ] Jobs CRUD operations
-- [ ] Bullet points CRUD with tagging
-- [ ] Skills management
-- [ ] Education and certifications management
-- [ ] Data service layer
-- [ ] Unit tests for services
+## Milestone Checklist
 
-### Week 3: Basic GUI
-- [ ] Main window with navigation
-- [ ] Profile editor dialog
-- [ ] Job editor with bullet point management
-- [ ] Skills editor
-- [ ] Data display views
-
-### Week 4: Matching Engine
+### ✅ Week 1: Foundation
+### ✅ Week 2: Core Data Management
+### ✅ Week 3: Basic GUI
+### 🔄 Week 4: Matching Engine
 - [ ] Job description parser
 - [ ] Keyword extraction
 - [ ] TF-IDF matching algorithm
@@ -138,201 +98,22 @@
 ## Technical Decisions Made
 
 ### Confirmed Decisions
-1. **Public repository** with MIT License
-2. **Technology Stack:**
+1. Public repository with MIT License.
+2. Technology stack:
    - Python 3.13.3
    - PyQt6 for desktop GUI
    - SQLite with SQLAlchemy ORM
    - ReportLab for PDF generation
    - spaCy for NLP/matching (Phase 2)
    - TF-IDF + tags for initial matching (Phase 1)
-3. **Git Flow:** Simplified (main, develop, feature/*)
-4. **Test Coverage Target:** 75% overall, 90%+ for critical components
-5. **Platform Support:** Windows and macOS
-6. **Package Management:** pyproject.toml with setuptools
-7. **Database Migrations:** Alembic with autogenerate
+3. Git Flow strategy: main, develop, feature/*.
+4. Test coverage targets: 75% overall, 90%+ for critical components.
+5. Platform support: Windows and macOS.
+6. Package management: `pyproject.toml` with setuptools.
+7. Database migrations: Alembic with autogenerate support.
 
 ### Pending Decisions
-- Specific resume template design choices
-- Cover letter template layouts
-- Exact matching algorithm parameters
-- GUI color scheme and styling
-
-## Next Steps
-
-### Immediate (Next Session)
-1. **Set up pytest** structure with conftest.py ⭐ NEXT
-2. **Write unit tests** for core models (Profile, Job, BulletPoint)
-3. **Commit to Git** - Save all Week 1 progress
-4. **Tag v0.1.0** - Foundation Complete
-
-### This Week (Week 1 Completion)
-1. ✅ Alembic migration system working
-2. ✅ Initial migration created and tested
-3. ⏭️ pytest framework established
-4. ⏭️ Basic unit tests for models
-5. ⏭️ Tag v0.1.0 - Foundation Complete
-
-### Next Week (Week 2)
-1. Begin Core Data Management phase
-2. Implement DataService layer for CRUD operations
-3. Build comprehensive test suite
-4. Establish code quality baseline (coverage, linting)
-5. Create data validation utilities
-
-## Metrics
-
-### Code Statistics
-- **Lines of Code:** ~2,700 (models + migrations)
-- **Test Coverage:** Not measured yet (pytest not set up)
-- **Models:** 14 tables implemented ✅
-- **Migrations:** 1 migration created ✅
-- **Database:** Initialized and working ✅
-- **Open Issues:** 0
-- **Pull Requests:** 0
-- **Commits:** ~2
-
-### Documentation
-- **Total Docs:** 9 complete
-- **ADRs:** 5 of 5 complete
-- **Foundation Completion:** ~95% (pytest pending)
-
-## Recent Changes
-
-### 2025-11-05 (Later Session)
-- **✨ Alembic migration system configured and working**
-  - Initialized Alembic in project
-  - Configured alembic.ini to use our database
-  - Modified env.py to import all models
-  - Added SQLite-specific options (render_as_batch)
-  - Generated initial migration with autogenerate
-  - Successfully ran `alembic upgrade head`
-  - Database created at ~/.adaptive_resume/resume_data.db
-  - All 14 tables created with constraints and indexes
-- **Updated documentation**
-  - Created ALEMBIC_SETUP.md with instructions
-  - Updated STATUS.md to reflect progress
-
-### 2025-11-05 (Earlier Session)
-- **✨ MAJOR: All SQLAlchemy models implemented and tested**
-  - Created 13 model files (~2,500 lines)
-  - Successfully tested all models with in-memory database
-  - Fixed import bug in tag.py (missing ForeignKey)
-  - Installed package in development mode
-- **Created comprehensive documentation**
-  - ARCHITECTURE.md (500 lines)
-  - DATABASE_SCHEMA.md (850 lines)
-  - MODELS_IMPLEMENTATION.md
-
-### 2025-11-04
-- Initial repository created and pushed to GitHub
-- Project structure established
-- Core documentation written
-- All 5 ADRs completed
-
-## Notes for Next Session
-
-### Priorities
-1. **pytest Setup** - Testing framework ⭐ NEXT
-   - Install: `pip install pytest pytest-cov`
-   - Create tests/ directory structure
-   - Create conftest.py with fixtures
-   - Write unit tests for Profile, Job, BulletPoint
-   - Run coverage report
-   - Target: 90%+ coverage for models
-
-2. **Git Commit** - Save all progress
-   - Review changes: `git status`
-   - Add all new files
-   - Commit with descriptive message
-   - Push to develop branch
-   - Tag v0.1.0 "Foundation Complete"
-
-3. **Week 2 Planning** - Prepare for next phase
-   - Review PROJECT_PLAN.md for Week 2 tasks
-   - Plan DataService layer architecture
-   - Identify first CRUD operations to implement
-
-### Important Reminders
-- ✅ All models working and tested
-- ✅ Alembic migrations configured and working
-- ✅ Database initialized successfully
-- ⏭️ Need pytest framework next
-- ⏭️ Need to commit progress to Git
-- 🎯 Foundation Phase ~95% complete!
-
-### Development Environment
-- **OS:** Windows 11
-- **Python:** 3.13.3
-- **Git:** 2.49.0.windows.1
-- **Project Path:** C:\Users\devon\Projects\adaptive-resume-generator
-- **GitHub:** https://github.com/AlobarQuest/adaptive-resume-generator
-- **Package:** Installed in development mode
-- **Database:** ~/.adaptive_resume/resume_data.db (created)
-
-### What's Working ✅
-✅ All 14 SQLAlchemy models  
-✅ Database configuration  
-✅ Session management  
-✅ Model relationships  
-✅ Constraints and validation  
-✅ JSON serialization (to_dict)  
-✅ Helper functions (seed_tags, create_default_template)  
-✅ Test script passes  
-✅ Alembic migrations configured  
-✅ Initial migration created  
-✅ Database initialized with all tables  
-
-### What's Next ⏭️
-⏭️ pytest framework  
-⏭️ Unit tests for models  
-⏭️ Git commit and tag v0.1.0  
-⏭️ Start Week 2 (DataService layer)  
-
-### Alembic Commands Reference
-```powershell
-# Create new migration
-alembic revision --autogenerate -m "Description of changes"
-
-# Apply migrations (upgrade to latest)
-alembic upgrade head
-
-# Rollback one migration
-alembic downgrade -1
-
-# Show current version
-alembic current
-
-# Show migration history
-alembic history
-
-# Show SQL without applying
-alembic upgrade head --sql
-```
-
-## Resources
-
-- **GitHub Repo:** https://github.com/AlobarQuest/adaptive-resume-generator
-- **Project Plan:** [PROJECT_PLAN.md](PROJECT_PLAN.md)
-- **Architecture:** [ARCHITECTURE.md](ARCHITECTURE.md)
-- **Database Schema:** [DATABASE_SCHEMA.md](DATABASE_SCHEMA.md)
-- **Models Guide:** [src/adaptive_resume/models/README.md](../src/adaptive_resume/models/README.md)
-- **Setup Guide:** [SETUP.md](SETUP.md)
-- **AI Guide:** [AI_SESSION_GUIDE.md](AI_SESSION_GUIDE.md)
-- **ADRs:** [docs/decisions/](decisions/)
-
-## Team
-
-**Developer:** AlobarQuest (Devon Watkins)  
-**Email:** devon.watkins@gmail.com  
-**Repository:** https://github.com/AlobarQuest/adaptive-resume-generator  
-**License:** MIT  
-**Status:** Active Development - Foundation Phase (95% Complete)
-
----
-
-**Current Session Achievement:** 🎉 Alembic migrations configured and database initialized!
-
-**Next Milestone:** Complete Foundation Phase (Week 1) with pytest and Git commit
-
-**Foundation Phase Progress:** 95% Complete - Almost there! 🚀
+- Specific resume template design choices.
+- Cover letter template layouts.
+- Exact matching algorithm parameters.
+- GUI color scheme and styling.

--- a/src/adaptive_resume/gui/__init__.py
+++ b/src/adaptive_resume/gui/__init__.py
@@ -1,0 +1,5 @@
+"""PyQt6 GUI package for the Adaptive Resume Generator."""
+
+from .main_window import MainWindow
+
+__all__ = ["MainWindow"]

--- a/src/adaptive_resume/gui/dialogs/__init__.py
+++ b/src/adaptive_resume/gui/dialogs/__init__.py
@@ -1,0 +1,6 @@
+"""Dialog components used across the Adaptive Resume GUI."""
+
+from .profile_dialog import ProfileDialog
+from .job_dialog import JobDialog
+
+__all__ = ["ProfileDialog", "JobDialog"]

--- a/src/adaptive_resume/gui/dialogs/job_dialog.py
+++ b/src/adaptive_resume/gui/dialogs/job_dialog.py
@@ -1,0 +1,162 @@
+"""Dialog for creating or editing job entries."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import List, Optional
+
+try:
+    from PyQt6.QtWidgets import (
+        QDialog,
+        QDialogButtonBox,
+        QFormLayout,
+        QHBoxLayout,
+        QLineEdit,
+        QListWidget,
+        QListWidgetItem,
+        QPushButton,
+        QTextEdit,
+        QWidget,
+        QVBoxLayout,
+    )
+except ImportError as exc:  # pragma: no cover
+    raise ImportError("PyQt6 is required to use the GUI components") from exc
+
+
+@dataclass
+class JobDialogResult:
+    """Return payload describing job data from the dialog."""
+
+    company_name: str
+    job_title: str
+    location: str
+    start_date: date
+    end_date: Optional[date]
+    is_current: bool
+    description: str
+    bullets: List[str]
+
+
+class JobDialog(QDialog):
+    """Dialog used to gather job information and bullet highlights."""
+
+    def __init__(self, parent: Optional[QWidget] = None, job: Optional[dict] = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Job")
+        self._build_form()
+        if job:
+            self._load_job(job)
+
+    def _build_form(self) -> None:
+        layout = QVBoxLayout(self)
+        form = QFormLayout()
+
+        self.company_name = QLineEdit()
+        self.job_title = QLineEdit()
+        self.location = QLineEdit()
+        self.start_date = self._date_field()
+        self.end_date = self._date_field()
+        self.description = QTextEdit()
+        self.description.setMaximumHeight(120)
+
+        form.addRow("Company", self.company_name)
+        form.addRow("Title", self.job_title)
+        form.addRow("Location", self.location)
+        form.addRow("Start Date", self.start_date)
+        form.addRow("End Date", self.end_date)
+        form.addRow("Description", self.description)
+
+        layout.addLayout(form)
+
+        bullets_header = QHBoxLayout()
+        self.bullets = QListWidget()
+        add_button = QPushButton("Add Bullet")
+        remove_button = QPushButton("Remove Selected")
+        add_button.clicked.connect(self._add_bullet)
+        remove_button.clicked.connect(self._remove_bullet)
+
+        bullets_header.addWidget(add_button)
+        bullets_header.addWidget(remove_button)
+
+        layout.addLayout(bullets_header)
+        layout.addWidget(self.bullets)
+
+        self.buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+        self.buttons.accepted.connect(self.accept)
+        self.buttons.rejected.connect(self.reject)
+        layout.addWidget(self.buttons)
+
+    def _date_field(self) -> QWidget:
+        widget = QLineEdit()
+        widget.setPlaceholderText("YYYY-MM-DD or leave blank")
+        return widget
+
+    def _load_job(self, job: dict) -> None:
+        self.company_name.setText(job.get("company_name", ""))
+        self.job_title.setText(job.get("job_title", ""))
+        self.location.setText(job.get("location", ""))
+        if job.get("start_date"):
+            self.start_date.setText(job["start_date"].strftime("%Y-%m-%d"))
+        if job.get("end_date"):
+            self.end_date.setText(job["end_date"].strftime("%Y-%m-%d"))
+        self.description.setPlainText(job.get("description", ""))
+        for bullet in job.get("bullets", []):
+            self.bullets.addItem(QListWidgetItem(bullet))
+
+    def _add_bullet(self) -> None:
+        text = QTextEdit()
+        text.setPlaceholderText("Enter bullet point (min 10 characters)")
+        text.setFixedHeight(80)
+        dialog = QDialog(self)
+        dialog.setWindowTitle("New Bullet")
+        inner_layout = QVBoxLayout(dialog)
+        inner_layout.addWidget(text)
+        button_box = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+        inner_layout.addWidget(button_box)
+        button_box.accepted.connect(dialog.accept)
+        button_box.rejected.connect(dialog.reject)
+        if dialog.exec() == int(QDialog.DialogCode.Accepted):
+            content = text.toPlainText().strip()
+            if content:
+                self.bullets.addItem(QListWidgetItem(content))
+        dialog.deleteLater()
+
+    def _remove_bullet(self) -> None:
+        row = self.bullets.currentRow()
+        if row >= 0:
+            item = self.bullets.takeItem(row)
+            del item
+
+    def _parse_date(self, text: str) -> Optional[date]:
+        text = text.strip()
+        if not text:
+            return None
+        try:
+            year, month, day = [int(part) for part in text.split("-")]
+            return date(year, month, day)
+        except ValueError as exc:  # pragma: no cover - validated in dialog
+            raise ValueError("Dates must be in YYYY-MM-DD format") from exc
+
+    def get_result(self) -> JobDialogResult:
+        """Return the captured job data."""
+        start = self._parse_date(self.start_date.text())
+        if start is None:
+            raise ValueError("Start date is required")
+
+        end = self._parse_date(self.end_date.text())
+
+        return JobDialogResult(
+            company_name=self.company_name.text().strip(),
+            job_title=self.job_title.text().strip(),
+            location=self.location.text().strip(),
+            start_date=start,
+            end_date=end,
+            is_current=end is None,
+            description=self.description.toPlainText().strip(),
+            bullets=[self.bullets.item(i).text() for i in range(self.bullets.count())],
+        )

--- a/src/adaptive_resume/gui/dialogs/profile_dialog.py
+++ b/src/adaptive_resume/gui/dialogs/profile_dialog.py
@@ -1,0 +1,100 @@
+"""Dialog for creating or editing profile information."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+try:
+    from PyQt6.QtWidgets import (
+        QDialog,
+        QDialogButtonBox,
+        QFormLayout,
+        QLineEdit,
+        QTextEdit,
+        QWidget,
+    )
+except ImportError as exc:  # pragma: no cover
+    raise ImportError("PyQt6 is required to use the GUI components") from exc
+
+
+@dataclass
+class ProfileDialogResult:
+    """Return payload describing profile data from the dialog."""
+
+    first_name: str
+    last_name: str
+    email: str
+    phone: str
+    city: str
+    state: str
+    linkedin_url: str
+    portfolio_url: str
+    professional_summary: str
+
+
+class ProfileDialog(QDialog):
+    """Simple dialog to gather profile information."""
+
+    def __init__(self, parent: Optional[QWidget] = None, profile: Optional[dict] = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Profile")
+        self._build_form()
+        if profile:
+            self._load_profile(profile)
+
+    def _build_form(self) -> None:
+        layout = QFormLayout(self)
+
+        self.first_name = QLineEdit()
+        self.last_name = QLineEdit()
+        self.email = QLineEdit()
+        self.phone = QLineEdit()
+        self.city = QLineEdit()
+        self.state = QLineEdit()
+        self.linkedin_url = QLineEdit()
+        self.portfolio_url = QLineEdit()
+        self.summary = QTextEdit()
+        self.summary.setMaximumHeight(120)
+
+        layout.addRow("First Name", self.first_name)
+        layout.addRow("Last Name", self.last_name)
+        layout.addRow("Email", self.email)
+        layout.addRow("Phone", self.phone)
+        layout.addRow("City", self.city)
+        layout.addRow("State", self.state)
+        layout.addRow("LinkedIn", self.linkedin_url)
+        layout.addRow("Portfolio", self.portfolio_url)
+        layout.addRow("Summary", self.summary)
+
+        self.buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+        self.buttons.accepted.connect(self.accept)
+        self.buttons.rejected.connect(self.reject)
+        layout.addRow(self.buttons)
+
+    def _load_profile(self, profile: dict) -> None:
+        self.first_name.setText(profile.get("first_name", ""))
+        self.last_name.setText(profile.get("last_name", ""))
+        self.email.setText(profile.get("email", ""))
+        self.phone.setText(profile.get("phone", ""))
+        self.city.setText(profile.get("city", ""))
+        self.state.setText(profile.get("state", ""))
+        self.linkedin_url.setText(profile.get("linkedin_url", ""))
+        self.portfolio_url.setText(profile.get("portfolio_url", ""))
+        self.summary.setPlainText(profile.get("professional_summary", ""))
+
+    def get_result(self) -> ProfileDialogResult:
+        """Return the captured profile data."""
+        return ProfileDialogResult(
+            first_name=self.first_name.text().strip(),
+            last_name=self.last_name.text().strip(),
+            email=self.email.text().strip(),
+            phone=self.phone.text().strip(),
+            city=self.city.text().strip(),
+            state=self.state.text().strip(),
+            linkedin_url=self.linkedin_url.text().strip(),
+            portfolio_url=self.portfolio_url.text().strip(),
+            professional_summary=self.summary.toPlainText().strip(),
+        )

--- a/src/adaptive_resume/gui/main_window.py
+++ b/src/adaptive_resume/gui/main_window.py
@@ -1,0 +1,370 @@
+"""Primary PyQt6 window for the Adaptive Resume Generator."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+try:
+    from PyQt6.QtCore import Qt
+    from PyQt6.QtWidgets import (
+        QAction,
+        QDialog,
+        QHBoxLayout,
+        QListWidget,
+        QListWidgetItem,
+        QMainWindow,
+        QMessageBox,
+        QPushButton,
+        QSplitter,
+        QStatusBar,
+        QToolBar,
+        QVBoxLayout,
+        QWidget,
+    )
+except ImportError as exc:  # pragma: no cover
+    raise ImportError("PyQt6 is required to use the GUI components") from exc
+
+from adaptive_resume.models import Profile
+from adaptive_resume.services.job_service import JobService
+from adaptive_resume.services.profile_service import ProfileService
+from adaptive_resume.services.skill_service import SkillService
+from adaptive_resume.services.education_service import EducationService
+from adaptive_resume.services.certification_service import CertificationService
+
+from .dialogs import JobDialog, ProfileDialog
+from .views import JobsView, SkillsSummaryView, ApplicationsView
+from .widgets import SkillsPanel, EducationPanel
+
+
+class MainWindow(QMainWindow):
+    """Top-level window coordinating navigation between resume editors."""
+
+    def __init__(
+        self,
+        profile_service: ProfileService,
+        job_service: JobService,
+        skill_service: Optional[SkillService] = None,
+        education_service: Optional[EducationService] = None,
+        certification_service: Optional[CertificationService] = None,
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        super().__init__(parent)
+        self.profile_service = profile_service
+        self.job_service = job_service
+        self.skill_service = skill_service or SkillService(profile_service.session)
+        self.education_service = education_service or EducationService(profile_service.session)
+        self.certification_service = certification_service or CertificationService(profile_service.session)
+        self.current_profile_id: Optional[int] = None
+
+        self.setWindowTitle("Adaptive Resume Generator")
+        self.resize(1200, 720)
+
+        self._setup_ui()
+        self._load_profiles()
+
+    # ------------------------------------------------------------------
+    # UI construction helpers
+    # ------------------------------------------------------------------
+    def _setup_ui(self) -> None:
+        central = QWidget(self)
+        layout = QHBoxLayout(central)
+
+        self.profile_list = QListWidget()
+        self.profile_list.currentItemChanged.connect(self._on_profile_selected)
+
+        left_panel = QVBoxLayout()
+        left_panel.addWidget(self.profile_list)
+
+        profile_buttons = QHBoxLayout()
+        self.add_profile_button = QPushButton("Add Profile")
+        self.edit_profile_button = QPushButton("Edit Profile")
+        self.add_profile_button.clicked.connect(self._add_profile)
+        self.edit_profile_button.clicked.connect(self._edit_profile)
+        profile_buttons.addWidget(self.add_profile_button)
+        profile_buttons.addWidget(self.edit_profile_button)
+        left_panel.addLayout(profile_buttons)
+
+        layout.addLayout(left_panel, 1)
+
+        splitter = QSplitter()
+        splitter.setOrientation(Qt.Orientation.Horizontal)
+
+        self.jobs_view = JobsView()
+        self.jobs_view.job_selected.connect(self._on_job_selected)
+
+        right_container = QWidget()
+        right_layout = QVBoxLayout(right_container)
+        right_layout.addWidget(self.jobs_view)
+
+        details_splitter = QSplitter()
+        details_splitter.setOrientation(Qt.Orientation.Horizontal)
+
+        self.skills_panel = SkillsPanel(self.skill_service)
+        self.education_panel = EducationPanel(self.education_service)
+        self.skills_summary_view = SkillsSummaryView()
+        self.applications_view = ApplicationsView()
+
+        details_splitter.addWidget(self.skills_panel)
+        details_splitter.addWidget(self.education_panel)
+        details_splitter.addWidget(self.skills_summary_view)
+
+        right_layout.addWidget(details_splitter)
+        right_layout.addWidget(self.applications_view)
+
+        splitter.addWidget(self.jobs_view)
+        splitter.addWidget(right_container)
+
+        layout.addWidget(splitter, 3)
+
+        central.setLayout(layout)
+        self.setCentralWidget(central)
+
+        self._build_toolbars()
+        self.setStatusBar(QStatusBar(self))
+
+    def _build_toolbars(self) -> None:
+        toolbar = QToolBar("Resume Actions", self)
+        toolbar.setMovable(False)
+        self.addToolBar(Qt.ToolBarArea.TopToolBarArea, toolbar)
+
+        add_job_action = QAction("Add Job", self)
+        add_job_action.triggered.connect(self._add_job)
+        toolbar.addAction(add_job_action)
+
+        edit_job_action = QAction("Edit Job", self)
+        edit_job_action.triggered.connect(self._edit_job)
+        toolbar.addAction(edit_job_action)
+
+        toolbar.addSeparator()
+
+        refresh_action = QAction("Refresh", self)
+        refresh_action.triggered.connect(self._refresh_current_profile)
+        toolbar.addAction(refresh_action)
+
+    # ------------------------------------------------------------------
+    # Data loading helpers
+    # ------------------------------------------------------------------
+    def _load_profiles(self) -> None:
+        self.profile_list.clear()
+        profiles = (
+            self.profile_service.session.query(Profile)
+            .order_by(Profile.last_name.asc(), Profile.first_name.asc())
+            .all()
+        )
+        for profile in profiles:
+            label = f"{profile.first_name} {profile.last_name}"
+            item = QListWidgetItem(label)
+            item.setData(Qt.ItemDataRole.UserRole, profile.id)
+            self.profile_list.addItem(item)
+
+        if profiles:
+            self.profile_list.setCurrentRow(0)
+        else:
+            self.current_profile_id = None
+            self.jobs_view.set_jobs([])
+            self.skills_panel.load_skills(None)
+            self.education_panel.load_education(None)
+            self.skills_summary_view.set_skills([])
+
+    def _refresh_current_profile(self) -> None:
+        if self.current_profile_id is not None:
+            self._load_profile_details(self.current_profile_id)
+
+    def _on_profile_selected(self, current: Optional[QListWidgetItem]) -> None:
+        if current is None:
+            self.current_profile_id = None
+            return
+
+        profile_id = int(current.data(Qt.ItemDataRole.UserRole))
+        self.current_profile_id = profile_id
+        self._load_profile_details(profile_id)
+        self.statusBar().showMessage(f"Loaded profile #{profile_id}", 3000)
+
+    def _load_profile_details(self, profile_id: int) -> None:
+        jobs = self.job_service.get_jobs_for_profile(profile_id)
+        self.jobs_view.set_jobs(jobs)
+        self.skills_panel.load_skills(profile_id)
+        self.education_panel.load_education(profile_id)
+
+        skills = self.skill_service.list_skills_for_profile(profile_id)
+        self.skills_summary_view.set_skills(skills)
+
+    def _on_job_selected(self, job_id: int) -> None:
+        if job_id <= 0:
+            self.jobs_view.show_job_details(None, [])
+            return
+
+        job = self.job_service.get_job_by_id(job_id)
+        bullets = self.job_service.get_bullet_points_for_job(job_id)
+        self.jobs_view.show_job_details(job, bullets)
+
+    # ------------------------------------------------------------------
+    # Dialog helpers
+    # ------------------------------------------------------------------
+    def _add_profile(self) -> None:
+        dialog = ProfileDialog(self)
+        if dialog.exec() == int(QDialog.DialogCode.Accepted):
+            data = dialog.get_result()
+            try:
+                profile = self.profile_service.create_profile(
+                    first_name=data.first_name,
+                    last_name=data.last_name,
+                    email=data.email,
+                    phone=data.phone or None,
+                    city=data.city or None,
+                    state=data.state or None,
+                    linkedin_url=data.linkedin_url or None,
+                    portfolio_url=data.portfolio_url or None,
+                    professional_summary=data.professional_summary or None,
+                )
+            except Exception as exc:  # pragma: no cover - relies on PyQt runtime
+                QMessageBox.critical(self, "Error", str(exc))
+                return
+
+            self._load_profiles()
+            self._select_profile(profile.id)
+
+    def _edit_profile(self) -> None:
+        profile_id = self.current_profile_id
+        if profile_id is None:
+            return
+
+        profile = self.profile_service.get_profile_by_id(profile_id)
+        dialog = ProfileDialog(
+            self,
+            profile={
+                "first_name": profile.first_name,
+                "last_name": profile.last_name,
+                "email": profile.email,
+                "phone": profile.phone or "",
+                "city": profile.city or "",
+                "state": profile.state or "",
+                "linkedin_url": profile.linkedin_url or "",
+                "portfolio_url": profile.portfolio_url or "",
+                "professional_summary": profile.professional_summary or "",
+            },
+        )
+        if dialog.exec() == int(QDialog.DialogCode.Accepted):
+            data = dialog.get_result()
+            try:
+                self.profile_service.update_profile(
+                    profile_id=profile_id,
+                    first_name=data.first_name,
+                    last_name=data.last_name,
+                    email=data.email,
+                    phone=data.phone or None,
+                    city=data.city or None,
+                    state=data.state or None,
+                    linkedin_url=data.linkedin_url or None,
+                    portfolio_url=data.portfolio_url or None,
+                    professional_summary=data.professional_summary or None,
+                )
+            except Exception as exc:  # pragma: no cover - relies on PyQt runtime
+                QMessageBox.critical(self, "Error", str(exc))
+                return
+
+            self._load_profiles()
+            self._select_profile(profile_id)
+
+    def _add_job(self) -> None:
+        if self.current_profile_id is None:
+            QMessageBox.information(self, "Select Profile", "Please choose a profile first.")
+            return
+
+        dialog = JobDialog(self)
+        if dialog.exec() == int(QDialog.DialogCode.Accepted):
+            data = dialog.get_result()
+            try:
+                job = self.job_service.create_job(
+                    profile_id=self.current_profile_id,
+                    company_name=data.company_name,
+                    job_title=data.job_title,
+                    start_date=data.start_date,
+                    end_date=data.end_date,
+                    is_current=data.is_current,
+                    location=data.location or None,
+                    description=data.description or None,
+                    display_order=0,
+                )
+                self._sync_bullets(job.id, data.bullets)
+            except Exception as exc:  # pragma: no cover
+                QMessageBox.critical(self, "Error", str(exc))
+                return
+
+            self._load_profile_details(self.current_profile_id)
+            self._select_job(job.id)
+
+    def _edit_job(self) -> None:
+        profile_id = self.current_profile_id
+        job_id = self.jobs_view.current_job_id()
+        if profile_id is None or job_id is None:
+            return
+
+        job = self.job_service.get_job_by_id(job_id)
+        bullets = self.job_service.get_bullet_points_for_job(job_id)
+        dialog = JobDialog(
+            self,
+            job={
+                "company_name": job.company_name,
+                "job_title": job.job_title,
+                "location": job.location or "",
+                "start_date": job.start_date,
+                "end_date": job.end_date,
+                "description": job.description or "",
+                "bullets": [bullet.content for bullet in bullets],
+            },
+        )
+        if dialog.exec() == int(QDialog.DialogCode.Accepted):
+            data = dialog.get_result()
+            try:
+                self.job_service.update_job(
+                    job_id=job_id,
+                    company_name=data.company_name,
+                    job_title=data.job_title,
+                    location=data.location or None,
+                    start_date=data.start_date,
+                    end_date=data.end_date,
+                    is_current=data.is_current,
+                    description=data.description or None,
+                )
+                self._sync_bullets(job_id, data.bullets)
+            except Exception as exc:  # pragma: no cover
+                QMessageBox.critical(self, "Error", str(exc))
+                return
+
+            self._load_profile_details(profile_id)
+            self._select_job(job_id)
+
+    def _sync_bullets(self, job_id: int, bullets: list[str]) -> None:
+        existing = self.job_service.get_bullet_points_for_job(job_id)
+        for bullet in existing:
+            self.job_service.delete_bullet_point(bullet.id)
+
+        for order, content in enumerate(bullets, start=1):
+            if len(content.strip()) < 10:
+                continue
+            self.job_service.create_bullet_point(
+                job_id=job_id,
+                content=content.strip(),
+                display_order=order,
+            )
+
+    # ------------------------------------------------------------------
+    # Utility helpers
+    # ------------------------------------------------------------------
+    def _select_profile(self, profile_id: int) -> None:
+        for index in range(self.profile_list.count()):
+            item = self.profile_list.item(index)
+            if int(item.data(Qt.ItemDataRole.UserRole)) == profile_id:
+                self.profile_list.setCurrentRow(index)
+                return
+
+    def _select_job(self, job_id: int) -> None:
+        for index in range(self.jobs_view.job_list.count()):
+            item = self.jobs_view.job_list.item(index)
+            if int(item.data(Qt.ItemDataRole.UserRole)) == job_id:
+                self.jobs_view.job_list.setCurrentRow(index)
+                return
+
+
+__all__ = ["MainWindow"]

--- a/src/adaptive_resume/gui/views/__init__.py
+++ b/src/adaptive_resume/gui/views/__init__.py
@@ -1,0 +1,7 @@
+"""High-level views rendered inside the main GUI window."""
+
+from .jobs_view import JobsView
+from .skills_summary_view import SkillsSummaryView
+from .applications_view import ApplicationsView
+
+__all__ = ["JobsView", "SkillsSummaryView", "ApplicationsView"]

--- a/src/adaptive_resume/gui/views/applications_view.py
+++ b/src/adaptive_resume/gui/views/applications_view.py
@@ -1,0 +1,23 @@
+"""Placeholder applications view for future expansion."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+try:
+    from PyQt6.QtWidgets import QLabel, QVBoxLayout, QWidget
+except ImportError as exc:  # pragma: no cover
+    raise ImportError("PyQt6 is required to use the GUI components") from exc
+
+
+class ApplicationsView(QWidget):
+    """Simple view that reserves space for application tracking."""
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        placeholder = QLabel(
+            "Application tracking will appear here once matching is complete."
+        )
+        placeholder.setWordWrap(True)
+        layout.addWidget(placeholder)

--- a/src/adaptive_resume/gui/views/jobs_view.py
+++ b/src/adaptive_resume/gui/views/jobs_view.py
@@ -1,0 +1,112 @@
+"""Job-focused view for the Adaptive Resume GUI."""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+try:
+    from PyQt6.QtCore import Qt, pyqtSignal
+    from PyQt6.QtWidgets import (
+        QListWidget,
+        QListWidgetItem,
+        QTextEdit,
+        QVBoxLayout,
+        QWidget,
+        QLabel,
+        QGroupBox,
+    )
+except ImportError as exc:  # pragma: no cover - handled by pytest.importorskip
+    raise ImportError("PyQt6 is required to use the GUI components") from exc
+
+from adaptive_resume.models import Job, BulletPoint
+
+
+class JobsView(QWidget):
+    """Display jobs and their associated bullet points."""
+
+    job_selected = pyqtSignal(int)
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self._jobs: list[Job] = []
+        self._setup_ui()
+
+    def _setup_ui(self) -> None:
+        layout = QVBoxLayout(self)
+
+        header = QLabel("Roles")
+        header.setObjectName("jobsViewHeader")
+        header.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
+        layout.addWidget(header)
+
+        self.job_list = QListWidget()
+        self.job_list.currentRowChanged.connect(self._on_job_selected)
+        layout.addWidget(self.job_list)
+
+        bullets_group = QGroupBox("Highlights")
+        bullets_layout = QVBoxLayout(bullets_group)
+
+        self.bullet_list = QListWidget()
+        bullets_layout.addWidget(self.bullet_list)
+
+        self.description = QTextEdit()
+        self.description.setReadOnly(True)
+        bullets_layout.addWidget(self.description)
+
+        layout.addWidget(bullets_group)
+
+    def set_jobs(self, jobs: Iterable[Job]) -> None:
+        """Load jobs into the view."""
+        self._jobs = list(jobs)
+        self.job_list.clear()
+        for job in self._jobs:
+            title = f"{job.job_title} at {job.company_name}"
+            item = QListWidgetItem(title)
+            item.setData(Qt.ItemDataRole.UserRole, job.id)
+            self.job_list.addItem(item)
+
+        if self._jobs:
+            self.job_list.setCurrentRow(0)
+        else:
+            self.bullet_list.clear()
+            self.description.clear()
+
+    def show_job_details(self, job: Optional[Job], bullets: Iterable[BulletPoint]) -> None:
+        """Render the details for a job selection."""
+        self.bullet_list.clear()
+        self.description.clear()
+
+        if not job:
+            return
+
+        for bullet in bullets:
+            item = QListWidgetItem(bullet.content)
+            item.setData(Qt.ItemDataRole.UserRole, bullet.id)
+            self.bullet_list.addItem(item)
+
+        description_lines: list[str] = []
+        if job.location:
+            description_lines.append(job.location)
+        if job.description:
+            description_lines.append(job.description)
+        if job.is_current:
+            description_lines.append("Currently employed")
+        elif job.end_date:
+            description_lines.append(f"Ended: {job.end_date:%b %Y}")
+
+        self.description.setPlainText("\n".join(description_lines))
+
+    def _on_job_selected(self, index: int) -> None:
+        if index < 0 or index >= len(self._jobs):
+            self.job_selected.emit(-1)
+            return
+
+        job = self._jobs[index]
+        self.job_selected.emit(job.id)
+
+    def current_job_id(self) -> Optional[int]:
+        """Return the currently selected job identifier."""
+        current_item = self.job_list.currentItem()
+        if current_item is None:
+            return None
+        return int(current_item.data(Qt.ItemDataRole.UserRole))

--- a/src/adaptive_resume/gui/views/skills_summary_view.py
+++ b/src/adaptive_resume/gui/views/skills_summary_view.py
@@ -1,0 +1,47 @@
+"""Summary view for skills grouped by category."""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+try:
+    from PyQt6.QtCore import Qt
+    from PyQt6.QtWidgets import QListWidget, QListWidgetItem, QVBoxLayout, QWidget, QLabel
+except ImportError as exc:  # pragma: no cover
+    raise ImportError("PyQt6 is required to use the GUI components") from exc
+
+from adaptive_resume.models import Skill
+
+
+class SkillsSummaryView(QWidget):
+    """Display aggregated skills grouped by category."""
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self._setup_ui()
+
+    def _setup_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        header = QLabel("Skill Overview")
+        header.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
+        layout.addWidget(header)
+
+        self.skill_list = QListWidget()
+        layout.addWidget(self.skill_list)
+
+    def set_skills(self, skills: Iterable[Skill]) -> None:
+        """Populate the view with the given skill rows."""
+        categories: dict[str, list[Skill]] = {}
+        for skill in skills:
+            categories.setdefault(skill.category or "Uncategorised", []).append(skill)
+
+        self.skill_list.clear()
+        for category, items in sorted(categories.items()):
+            item = QListWidgetItem(f"{category} ({len(items)})")
+            item.setFlags(Qt.ItemFlag.ItemIsEnabled)
+            self.skill_list.addItem(item)
+            for skill in items:
+                detail = f"  • {skill.skill_name} — {skill.proficiency_level or 'N/A'}"
+                detail_item = QListWidgetItem(detail)
+                detail_item.setFlags(Qt.ItemFlag.ItemIsEnabled)
+                self.skill_list.addItem(detail_item)

--- a/src/adaptive_resume/gui/widgets/__init__.py
+++ b/src/adaptive_resume/gui/widgets/__init__.py
@@ -1,0 +1,6 @@
+"""Reusable widgets used by the Adaptive Resume GUI."""
+
+from .skills_panel import SkillsPanel
+from .education_panel import EducationPanel
+
+__all__ = ["SkillsPanel", "EducationPanel"]

--- a/src/adaptive_resume/gui/widgets/education_panel.py
+++ b/src/adaptive_resume/gui/widgets/education_panel.py
@@ -1,0 +1,48 @@
+"""Education management panel for the GUI."""
+
+from __future__ import annotations
+
+from typing import Optional, TYPE_CHECKING
+
+try:
+    from PyQt6.QtCore import Qt
+    from PyQt6.QtWidgets import QListWidget, QListWidgetItem, QVBoxLayout, QWidget, QLabel
+except ImportError as exc:  # pragma: no cover
+    raise ImportError("PyQt6 is required to use the GUI components") from exc
+
+from adaptive_resume.models import Education
+
+if TYPE_CHECKING:
+    from adaptive_resume.services.education_service import EducationService
+
+
+class EducationPanel(QWidget):
+    """Display ordered education history for the active profile."""
+
+    def __init__(self, education_service: "EducationService", parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self.education_service = education_service
+        self._setup_ui()
+
+    def _setup_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        header = QLabel("Education")
+        header.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
+        layout.addWidget(header)
+
+        self.education_list = QListWidget()
+        layout.addWidget(self.education_list)
+
+    def load_education(self, profile_id: Optional[int]) -> None:
+        """Refresh the list of education entries for the given profile."""
+        self.education_list.clear()
+        if profile_id is None:
+            return
+
+        entries = self.education_service.list_education_for_profile(profile_id)
+
+        for education in entries:
+            label = f"{education.degree or 'Education'} — {education.institution}"
+            item = QListWidgetItem(label)
+            item.setData(Qt.ItemDataRole.UserRole, education.id)
+            self.education_list.addItem(item)

--- a/src/adaptive_resume/gui/widgets/skills_panel.py
+++ b/src/adaptive_resume/gui/widgets/skills_panel.py
@@ -1,0 +1,48 @@
+"""Skills management panel for the GUI."""
+
+from __future__ import annotations
+
+from typing import Optional, TYPE_CHECKING
+
+try:
+    from PyQt6.QtCore import Qt
+    from PyQt6.QtWidgets import QListWidget, QListWidgetItem, QVBoxLayout, QWidget, QLabel
+except ImportError as exc:  # pragma: no cover
+    raise ImportError("PyQt6 is required to use the GUI components") from exc
+
+from adaptive_resume.models import Skill
+
+if TYPE_CHECKING:
+    from adaptive_resume.services.skill_service import SkillService
+
+
+class SkillsPanel(QWidget):
+    """Display ordered skills for the active profile."""
+
+    def __init__(self, skill_service: "SkillService", parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self.skill_service = skill_service
+        self._setup_ui()
+
+    def _setup_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        header = QLabel("Skills")
+        header.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
+        layout.addWidget(header)
+
+        self.skill_list = QListWidget()
+        layout.addWidget(self.skill_list)
+
+    def load_skills(self, profile_id: Optional[int]) -> None:
+        """Refresh the list of skills for the given profile."""
+        self.skill_list.clear()
+        if profile_id is None:
+            return
+
+        skills = self.skill_service.list_skills_for_profile(profile_id)
+
+        for skill in skills:
+            label = f"{skill.skill_name} ({skill.proficiency_level or 'Unknown'})"
+            item = QListWidgetItem(label)
+            item.setData(Qt.ItemDataRole.UserRole, skill.id)
+            self.skill_list.addItem(item)

--- a/src/adaptive_resume/services/__init__.py
+++ b/src/adaptive_resume/services/__init__.py
@@ -1,12 +1,17 @@
-"""
-Services package for Adaptive Resume Generator.
+"""Services package for Adaptive Resume Generator."""
 
-This package contains business logic services that orchestrate
-operations across models, provide validation, and implement
-application-specific rules.
-
-Services act as the layer between the GUI and the database models,
-providing a clean API for all business operations.
-"""
+from .profile_service import ProfileService
+from .job_service import JobService
+from .skill_service import SkillService
+from .education_service import EducationService
+from .certification_service import CertificationService
 
 __version__ = '0.1.0'
+
+__all__ = [
+    'ProfileService',
+    'JobService',
+    'SkillService',
+    'EducationService',
+    'CertificationService',
+]

--- a/src/adaptive_resume/services/certification_service.py
+++ b/src/adaptive_resume/services/certification_service.py
@@ -1,0 +1,174 @@
+"""Service layer for managing professional certifications."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Iterable, List, Optional
+
+from sqlalchemy.orm import Session
+
+from adaptive_resume.models import Certification, Profile
+
+
+class CertificationServiceError(Exception):
+    """Base exception for certification service errors."""
+
+
+class CertificationNotFoundError(CertificationServiceError):
+    """Raised when a certification record cannot be located."""
+
+
+class CertificationValidationError(CertificationServiceError):
+    """Raised when certification data fails validation."""
+
+
+class CertificationService:
+    """Business logic for CRUD operations on certifications."""
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    def create_certification(
+        self,
+        profile_id: int,
+        name: str,
+        issuing_organization: str,
+        issue_date: Optional[date] = None,
+        expiration_date: Optional[date] = None,
+        credential_id: Optional[str] = None,
+        credential_url: Optional[str] = None,
+        display_order: Optional[int] = None,
+    ) -> Certification:
+        self._ensure_profile_exists(profile_id)
+        self._validate_required(name, issuing_organization)
+        self._validate_dates(issue_date, expiration_date)
+
+        certification = Certification(
+            profile_id=profile_id,
+            name=name.strip(),
+            issuing_organization=issuing_organization.strip(),
+            issue_date=issue_date,
+            expiration_date=expiration_date,
+            credential_id=credential_id.strip() if credential_id else None,
+            credential_url=credential_url.strip() if credential_url else None,
+            display_order=display_order
+            if display_order is not None
+            else self._next_display_order(profile_id),
+        )
+        self.session.add(certification)
+        self.session.commit()
+        self.session.refresh(certification)
+        return certification
+
+    def update_certification(
+        self,
+        certification_id: int,
+        *,
+        name: Optional[str] = None,
+        issuing_organization: Optional[str] = None,
+        issue_date: Optional[date] = None,
+        expiration_date: Optional[date] = None,
+        credential_id: Optional[str] = None,
+        credential_url: Optional[str] = None,
+        display_order: Optional[int] = None,
+    ) -> Certification:
+        certification = self.get_certification_by_id(certification_id)
+
+        if name is not None:
+            if not name.strip():
+                raise CertificationValidationError("Certification name cannot be empty")
+            certification.name = name.strip()
+
+        if issuing_organization is not None:
+            if not issuing_organization.strip():
+                raise CertificationValidationError("Issuing organization cannot be empty")
+            certification.issuing_organization = issuing_organization.strip()
+
+        if issue_date is not None or expiration_date is not None:
+            self._validate_dates(issue_date or certification.issue_date, expiration_date or certification.expiration_date)
+            if issue_date is not None:
+                certification.issue_date = issue_date
+            if expiration_date is not None:
+                certification.expiration_date = expiration_date
+
+        if credential_id is not None:
+            certification.credential_id = credential_id.strip() if credential_id.strip() else None
+
+        if credential_url is not None:
+            certification.credential_url = credential_url.strip() if credential_url.strip() else None
+
+        if display_order is not None:
+            if display_order < 0:
+                raise CertificationValidationError("Display order must be positive")
+            certification.display_order = display_order
+
+        self.session.commit()
+        self.session.refresh(certification)
+        return certification
+
+    def delete_certification(self, certification_id: int) -> None:
+        certification = self.get_certification_by_id(certification_id)
+        self.session.delete(certification)
+        self.session.commit()
+
+    def get_certification_by_id(self, certification_id: int) -> Certification:
+        certification = self.session.query(Certification).filter_by(id=certification_id).first()
+        if not certification:
+            raise CertificationNotFoundError(f"Certification with id {certification_id} not found")
+        return certification
+
+    def list_certifications_for_profile(self, profile_id: int) -> List[Certification]:
+        return (
+            self.session.query(Certification)
+            .filter_by(profile_id=profile_id)
+            .order_by(Certification.display_order.asc(), Certification.issue_date.desc())
+            .all()
+        )
+
+    def reorder_certifications(self, profile_id: int, ordered_ids: Iterable[int]) -> None:
+        certifications = self.list_certifications_for_profile(profile_id)
+        id_map = {cert.id: cert for cert in certifications}
+        for position, certification_id in enumerate(ordered_ids):
+            if certification_id in id_map:
+                id_map[certification_id].display_order = position
+        self.session.commit()
+
+    # ------------------------------------------------------------------
+    # Validation helpers
+    # ------------------------------------------------------------------
+    def _ensure_profile_exists(self, profile_id: int) -> None:
+        exists = self.session.query(Profile.id).filter_by(id=profile_id).scalar()
+        if not exists:
+            raise CertificationValidationError(f"Profile with id {profile_id} does not exist")
+
+    def _validate_required(self, name: str, issuing_organization: str) -> None:
+        if not name or not name.strip():
+            raise CertificationValidationError("Certification name is required")
+        if not issuing_organization or not issuing_organization.strip():
+            raise CertificationValidationError("Issuing organization is required")
+
+    def _validate_dates(
+        self,
+        issue_date: Optional[date],
+        expiration_date: Optional[date],
+    ) -> None:
+        if issue_date and expiration_date and expiration_date < issue_date:
+            raise CertificationValidationError("Expiration date cannot be before issue date")
+
+    def _next_display_order(self, profile_id: int) -> int:
+        current_max = (
+            self.session.query(Certification.display_order)
+            .filter_by(profile_id=profile_id)
+            .order_by(Certification.display_order.desc())
+            .limit(1)
+            .scalar()
+        )
+        return (current_max or 0) + 1
+
+
+__all__ = [
+    "CertificationService",
+    "CertificationServiceError",
+    "CertificationNotFoundError",
+    "CertificationValidationError",
+]

--- a/src/adaptive_resume/services/education_service.py
+++ b/src/adaptive_resume/services/education_service.py
@@ -1,0 +1,188 @@
+"""Service layer for managing education history."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Iterable, List, Optional
+
+from sqlalchemy.orm import Session
+
+from adaptive_resume.models import Education, Profile
+
+
+class EducationServiceError(Exception):
+    """Base exception for education service failures."""
+
+
+class EducationNotFoundError(EducationServiceError):
+    """Raised when an education record cannot be located."""
+
+
+class EducationValidationError(EducationServiceError):
+    """Raised when provided education data is invalid."""
+
+
+class EducationService:
+    """Business logic for CRUD operations on education entries."""
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    def create_education(
+        self,
+        profile_id: int,
+        institution: str,
+        degree: str,
+        field_of_study: Optional[str] = None,
+        start_date: Optional[date] = None,
+        end_date: Optional[date] = None,
+        gpa: Optional[float] = None,
+        honors: Optional[str] = None,
+        relevant_coursework: Optional[str] = None,
+        display_order: Optional[int] = None,
+    ) -> Education:
+        self._ensure_profile_exists(profile_id)
+        self._validate_dates(start_date, end_date)
+        self._validate_required(institution, degree)
+
+        education = Education(
+            profile_id=profile_id,
+            institution=institution.strip(),
+            degree=degree.strip(),
+            field_of_study=field_of_study.strip() if field_of_study else None,
+            start_date=start_date,
+            end_date=end_date,
+            gpa=gpa,
+            honors=honors.strip() if honors else None,
+            relevant_coursework=relevant_coursework.strip() if relevant_coursework else None,
+            display_order=display_order
+            if display_order is not None
+            else self._next_display_order(profile_id),
+        )
+        self.session.add(education)
+        self.session.commit()
+        self.session.refresh(education)
+        return education
+
+    def update_education(
+        self,
+        education_id: int,
+        *,
+        institution: Optional[str] = None,
+        degree: Optional[str] = None,
+        field_of_study: Optional[str] = None,
+        start_date: Optional[date] = None,
+        end_date: Optional[date] = None,
+        gpa: Optional[float] = None,
+        honors: Optional[str] = None,
+        relevant_coursework: Optional[str] = None,
+        display_order: Optional[int] = None,
+    ) -> Education:
+        education = self.get_education_by_id(education_id)
+
+        if institution is not None:
+            if not institution.strip():
+                raise EducationValidationError("Institution cannot be empty")
+            education.institution = institution.strip()
+
+        if degree is not None:
+            if not degree.strip():
+                raise EducationValidationError("Degree cannot be empty")
+            education.degree = degree.strip()
+
+        if field_of_study is not None:
+            education.field_of_study = field_of_study.strip() if field_of_study.strip() else None
+
+        if start_date is not None or end_date is not None:
+            self._validate_dates(start_date or education.start_date, end_date or education.end_date)
+            if start_date is not None:
+                education.start_date = start_date
+            if end_date is not None:
+                education.end_date = end_date
+
+        if gpa is not None:
+            if gpa < 0 or gpa > 4:
+                raise EducationValidationError("GPA must be between 0.0 and 4.0")
+            education.gpa = gpa
+
+        if honors is not None:
+            education.honors = honors.strip() if honors.strip() else None
+
+        if relevant_coursework is not None:
+            education.relevant_coursework = (
+                relevant_coursework.strip() if relevant_coursework.strip() else None
+            )
+
+        if display_order is not None:
+            if display_order < 0:
+                raise EducationValidationError("Display order must be positive")
+            education.display_order = display_order
+
+        self.session.commit()
+        self.session.refresh(education)
+        return education
+
+    def delete_education(self, education_id: int) -> None:
+        education = self.get_education_by_id(education_id)
+        self.session.delete(education)
+        self.session.commit()
+
+    def get_education_by_id(self, education_id: int) -> Education:
+        education = self.session.query(Education).filter_by(id=education_id).first()
+        if not education:
+            raise EducationNotFoundError(f"Education with id {education_id} not found")
+        return education
+
+    def list_education_for_profile(self, profile_id: int) -> List[Education]:
+        return (
+            self.session.query(Education)
+            .filter_by(profile_id=profile_id)
+            .order_by(Education.display_order.asc(), Education.start_date.desc())
+            .all()
+        )
+
+    def reorder_education(self, profile_id: int, ordered_ids: Iterable[int]) -> None:
+        education_entries = self.list_education_for_profile(profile_id)
+        id_map = {entry.id: entry for entry in education_entries}
+        for position, education_id in enumerate(ordered_ids):
+            if education_id in id_map:
+                id_map[education_id].display_order = position
+        self.session.commit()
+
+    # ------------------------------------------------------------------
+    # Validation helpers
+    # ------------------------------------------------------------------
+    def _ensure_profile_exists(self, profile_id: int) -> None:
+        exists = self.session.query(Profile.id).filter_by(id=profile_id).scalar()
+        if not exists:
+            raise EducationValidationError(f"Profile with id {profile_id} does not exist")
+
+    def _validate_dates(
+        self, start_date: Optional[date], end_date: Optional[date]
+    ) -> None:
+        if start_date and end_date and end_date < start_date:
+            raise EducationValidationError("End date cannot be before start date")
+
+    def _validate_required(self, institution: str, degree: str) -> None:
+        if not institution or not institution.strip():
+            raise EducationValidationError("Institution is required")
+        if not degree or not degree.strip():
+            raise EducationValidationError("Degree is required")
+
+    def _next_display_order(self, profile_id: int) -> int:
+        current_max = (
+            self.session.query(Education.display_order)
+            .filter_by(profile_id=profile_id)
+            .order_by(Education.display_order.desc())
+            .limit(1)
+            .scalar()
+        )
+        return (current_max or 0) + 1
+
+
+__all__ = [
+    "EducationService",
+    "EducationServiceError",
+    "EducationNotFoundError",
+    "EducationValidationError",
+]

--- a/src/adaptive_resume/services/skill_service.py
+++ b/src/adaptive_resume/services/skill_service.py
@@ -1,0 +1,175 @@
+"""Service layer for managing skill records."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Iterable, List, Optional
+
+from sqlalchemy.orm import Session
+
+from adaptive_resume.models import Profile, Skill
+
+
+class SkillServiceError(Exception):
+    """Base exception for skill service failures."""
+
+
+class SkillNotFoundError(SkillServiceError):
+    """Raised when a requested skill cannot be located."""
+
+
+class SkillValidationError(SkillServiceError):
+    """Raised when provided skill data is invalid."""
+
+
+class SkillService:
+    """Business logic for creating, updating, and ordering skills."""
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    # ------------------------------------------------------------------
+    # CRUD operations
+    # ------------------------------------------------------------------
+    def create_skill(
+        self,
+        profile_id: int,
+        skill_name: str,
+        category: Optional[str] = None,
+        proficiency_level: Optional[str] = None,
+        years_experience: Optional[float] = None,
+        display_order: Optional[int] = None,
+    ) -> Skill:
+        self._ensure_profile_exists(profile_id)
+        self._validate_skill(skill_name, proficiency_level, years_experience)
+
+        skill = Skill(
+            profile_id=profile_id,
+            skill_name=skill_name.strip(),
+            category=category.strip() if category else None,
+            proficiency_level=proficiency_level.strip() if proficiency_level else None,
+            years_experience=self._to_decimal(years_experience),
+            display_order=display_order
+            if display_order is not None
+            else self._next_display_order(profile_id),
+        )
+        self.session.add(skill)
+        self.session.commit()
+        self.session.refresh(skill)
+        return skill
+
+    def update_skill(
+        self,
+        skill_id: int,
+        *,
+        skill_name: Optional[str] = None,
+        category: Optional[str] = None,
+        proficiency_level: Optional[str] = None,
+        years_experience: Optional[float] = None,
+        display_order: Optional[int] = None,
+    ) -> Skill:
+        skill = self.get_skill_by_id(skill_id)
+
+        if skill_name is not None:
+            if not skill_name.strip():
+                raise SkillValidationError("Skill name cannot be empty")
+            skill.skill_name = skill_name.strip()
+
+        if category is not None:
+            skill.category = category.strip() if category.strip() else None
+
+        if proficiency_level is not None:
+            self._validate_proficiency(proficiency_level)
+            skill.proficiency_level = proficiency_level.strip() if proficiency_level.strip() else None
+
+        if years_experience is not None:
+            if years_experience < 0:
+                raise SkillValidationError("Years of experience must be positive")
+            skill.years_experience = self._to_decimal(years_experience)
+
+        if display_order is not None:
+            if display_order < 0:
+                raise SkillValidationError("Display order must be positive")
+            skill.display_order = display_order
+
+        self.session.commit()
+        self.session.refresh(skill)
+        return skill
+
+    def delete_skill(self, skill_id: int) -> None:
+        skill = self.get_skill_by_id(skill_id)
+        self.session.delete(skill)
+        self.session.commit()
+
+    def get_skill_by_id(self, skill_id: int) -> Skill:
+        skill = self.session.query(Skill).filter_by(id=skill_id).first()
+        if not skill:
+            raise SkillNotFoundError(f"Skill with id {skill_id} not found")
+        return skill
+
+    def list_skills_for_profile(self, profile_id: int) -> List[Skill]:
+        return (
+            self.session.query(Skill)
+            .filter_by(profile_id=profile_id)
+            .order_by(Skill.display_order.asc(), Skill.skill_name.asc())
+            .all()
+        )
+
+    def reorder_skills(self, profile_id: int, ordered_ids: Iterable[int]) -> None:
+        skills = self.list_skills_for_profile(profile_id)
+        id_map = {skill.id: skill for skill in skills}
+        for position, skill_id in enumerate(ordered_ids):
+            if skill_id in id_map:
+                id_map[skill_id].display_order = position
+        self.session.commit()
+
+    # ------------------------------------------------------------------
+    # Validation helpers
+    # ------------------------------------------------------------------
+    def _ensure_profile_exists(self, profile_id: int) -> None:
+        exists = self.session.query(Profile.id).filter_by(id=profile_id).scalar()
+        if not exists:
+            raise SkillValidationError(f"Profile with id {profile_id} does not exist")
+
+    def _validate_skill(
+        self,
+        skill_name: str,
+        proficiency_level: Optional[str],
+        years_experience: Optional[float],
+    ) -> None:
+        if not skill_name or not skill_name.strip():
+            raise SkillValidationError("Skill name is required")
+        if proficiency_level:
+            self._validate_proficiency(proficiency_level)
+        if years_experience is not None and years_experience < 0:
+            raise SkillValidationError("Years of experience must be positive")
+
+    def _validate_proficiency(self, level: str) -> None:
+        level = level.strip()
+        if level and level not in Skill.PROFICIENCY_LEVELS:
+            raise SkillValidationError(
+                f"Invalid proficiency level '{level}'. Expected one of {Skill.PROFICIENCY_LEVELS}"
+            )
+
+    def _next_display_order(self, profile_id: int) -> int:
+        current_max = (
+            self.session.query(Skill.display_order)
+            .filter_by(profile_id=profile_id)
+            .order_by(Skill.display_order.desc())
+            .limit(1)
+            .scalar()
+        )
+        return (current_max or 0) + 1
+
+    def _to_decimal(self, value: Optional[float]) -> Optional[Decimal]:
+        if value is None:
+            return None
+        return Decimal(str(round(value, 1)))
+
+
+__all__ = [
+    "SkillService",
+    "SkillServiceError",
+    "SkillNotFoundError",
+    "SkillValidationError",
+]

--- a/tests/unit/test_certification_service.py
+++ b/tests/unit/test_certification_service.py
@@ -1,0 +1,69 @@
+"""Unit tests for the CertificationService."""
+
+from datetime import date
+
+import pytest
+
+from adaptive_resume.services.certification_service import (
+    CertificationService,
+    CertificationNotFoundError,
+    CertificationValidationError,
+)
+from adaptive_resume.services.profile_service import ProfileService
+
+
+def test_create_list_and_update_certification(session):
+    profile_service = ProfileService(session)
+    profile = profile_service.create_profile(
+        first_name="Alex",
+        last_name="Jones",
+        email="alex.jones@example.com",
+    )
+
+    service = CertificationService(session)
+    certification = service.create_certification(
+        profile_id=profile.id,
+        name="AWS Solutions Architect",
+        issuing_organization="Amazon",
+        issue_date=date(2022, 1, 1),
+        expiration_date=date(2025, 1, 1),
+        credential_id="AWS-123",
+    )
+
+    assert certification.id is not None
+    assert certification.name == "AWS Solutions Architect"
+
+    certifications = service.list_certifications_for_profile(profile.id)
+    assert len(certifications) == 1
+
+    updated = service.update_certification(certification.id, credential_url="https://aws.amazon.com")
+    assert updated.credential_url == "https://aws.amazon.com"
+
+    service.reorder_certifications(profile.id, [certification.id])
+
+    service.delete_certification(certification.id)
+    with pytest.raises(CertificationNotFoundError):
+        service.get_certification_by_id(certification.id)
+
+
+def test_create_certification_validates_input(session):
+    profile_service = ProfileService(session)
+    profile = profile_service.create_profile(
+        first_name="Riley",
+        last_name="Nguyen",
+        email="riley.nguyen@example.com",
+    )
+
+    service = CertificationService(session)
+
+    with pytest.raises(CertificationValidationError):
+        service.create_certification(profile.id, name="", issuing_organization="AWS")
+
+    with pytest.raises(CertificationValidationError):
+        service.create_certification(
+            profile.id,
+            name="Azure Architect",
+            issuing_organization="Microsoft",
+            issue_date=date(2021, 5, 1),
+            expiration_date=date(2020, 5, 1),
+        )

--- a/tests/unit/test_education_service.py
+++ b/tests/unit/test_education_service.py
@@ -1,0 +1,80 @@
+"""Unit tests for the EducationService."""
+
+from datetime import date
+
+import pytest
+
+from adaptive_resume.services.education_service import (
+    EducationService,
+    EducationNotFoundError,
+    EducationValidationError,
+)
+from adaptive_resume.services.profile_service import ProfileService
+
+
+def test_create_list_and_update_education(session):
+    profile_service = ProfileService(session)
+    profile = profile_service.create_profile(
+        first_name="Jamie",
+        last_name="Reed",
+        email="jamie.reed@example.com",
+    )
+
+    service = EducationService(session)
+    education = service.create_education(
+        profile_id=profile.id,
+        institution="Georgia Tech",
+        degree="BS Computer Science",
+        start_date=date(2010, 8, 1),
+        end_date=date(2014, 5, 1),
+        gpa=3.9,
+    )
+
+    assert education.id is not None
+    assert education.institution == "Georgia Tech"
+
+    entries = service.list_education_for_profile(profile.id)
+    assert len(entries) == 1
+
+    updated = service.update_education(education.id, honors="Magna Cum Laude", gpa=3.95)
+    assert updated.honors == "Magna Cum Laude"
+    assert float(updated.gpa) == 3.95
+
+    service.reorder_education(profile.id, [education.id])
+
+    service.delete_education(education.id)
+    with pytest.raises(EducationNotFoundError):
+        service.get_education_by_id(education.id)
+
+
+def test_create_education_validates_input(session):
+    profile_service = ProfileService(session)
+    profile = profile_service.create_profile(
+        first_name="Morgan",
+        last_name="Lee",
+        email="morgan.lee@example.com",
+    )
+
+    service = EducationService(session)
+
+    with pytest.raises(EducationValidationError):
+        service.create_education(profile.id, institution="", degree="BBA")
+
+    with pytest.raises(EducationValidationError):
+        service.create_education(
+            profile.id,
+            institution="State University",
+            degree="MBA",
+            start_date=date(2020, 1, 1),
+            end_date=date(2019, 1, 1),
+        )
+
+    with pytest.raises(EducationValidationError):
+        service.update_education(
+            service.create_education(
+                profile.id,
+                institution="State University",
+                degree="MBA",
+            ).id,
+            gpa=4.5,
+        )

--- a/tests/unit/test_gui_dialogs.py
+++ b/tests/unit/test_gui_dialogs.py
@@ -1,0 +1,50 @@
+"""Smoke tests for PyQt6 dialog components."""
+
+import pytest
+
+PyQt6 = pytest.importorskip("PyQt6")  # noqa: F401  # pragma: no cover
+try:  # pragma: no cover - platform-dependent import guard
+    from PyQt6.QtWidgets import QApplication
+except Exception as exc:  # pragma: no cover
+    pytest.skip(f"PyQt6 GUI dependencies unavailable: {exc}", allow_module_level=True)
+
+from adaptive_resume.gui.dialogs import JobDialog, ProfileDialog
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    yield app
+
+
+def test_profile_dialog_returns_data(qapp):
+    dialog = ProfileDialog(
+        profile={
+            "first_name": "Jane",
+            "last_name": "Doe",
+            "email": "jane@example.com",
+            "city": "Atlanta",
+        }
+    )
+    result = dialog.get_result()
+    assert result.first_name == "Jane"
+    assert result.email == "jane@example.com"
+    dialog.close()
+
+
+def test_job_dialog_returns_data(qapp):
+    dialog = JobDialog()
+    dialog.company_name.setText("TechCorp")
+    dialog.job_title.setText("Manager")
+    dialog.location.setText("Remote")
+    dialog.start_date.setText("2020-01-01")
+    dialog.description.setPlainText("Led a distributed engineering team.")
+    dialog.bullets.addItem("Increased retention by 20% through mentorship programs")
+
+    result = dialog.get_result()
+    assert result.company_name == "TechCorp"
+    assert result.start_date.year == 2020
+    assert result.bullets
+    dialog.close()

--- a/tests/unit/test_gui_main_window.py
+++ b/tests/unit/test_gui_main_window.py
@@ -1,0 +1,88 @@
+"""Smoke tests for the PyQt6 main window."""
+
+import pytest
+from datetime import date
+
+PyQt6 = pytest.importorskip("PyQt6")  # noqa: F401  # pragma: no cover
+try:  # pragma: no cover - platform-dependent import guard
+    from PyQt6.QtWidgets import QApplication
+except Exception as exc:  # pragma: no cover
+    pytest.skip(f"PyQt6 GUI dependencies unavailable: {exc}", allow_module_level=True)
+
+from adaptive_resume.gui.main_window import MainWindow
+from adaptive_resume.services.job_service import JobService
+from adaptive_resume.services.profile_service import ProfileService
+from adaptive_resume.models import Skill, Education
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    """Provide a shared QApplication instance for GUI tests."""
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    yield app
+
+
+def test_main_window_loads_profile_data(qapp, session):
+    profile_service = ProfileService(session)
+    job_service = JobService(session)
+
+    profile = profile_service.create_profile(
+        first_name="Jane",
+        last_name="Doe",
+        email="jane.doe@example.com",
+        phone="555-000-1234",
+        city="Atlanta",
+        state="GA",
+        professional_summary="Experienced leader",
+    )
+
+    job = job_service.create_job(
+        profile_id=profile.id,
+        company_name="TechCorp",
+        job_title="Program Manager",
+        start_date=date(2020, 1, 1),
+        end_date=None,
+        is_current=True,
+        location="Remote",
+        description="Led strategic initiatives.",
+    )
+    job_service.create_bullet_point(
+        job_id=job.id,
+        content="Delivered a 25% revenue increase through cross-functional delivery.",
+        display_order=1,
+    )
+
+    session.add(
+        Skill(
+            profile_id=profile.id,
+            skill_name="Leadership",
+            category="Soft Skills",
+            proficiency_level="Advanced",
+            years_experience=12,
+            display_order=1,
+        )
+    )
+    session.add(
+        Education(
+            profile_id=profile.id,
+            institution="Georgia Tech",
+            degree="BS Computer Science",
+            field_of_study="Computer Science",
+            start_date=date(2005, 8, 1),
+            end_date=date(2009, 5, 1),
+            display_order=1,
+        )
+    )
+    session.commit()
+
+    window = MainWindow(profile_service, job_service)
+    try:
+        assert window.profile_list.count() == 1
+        assert window.jobs_view.job_list.count() == 1
+        assert window.skills_panel.skill_list.count() == 1
+        assert window.education_panel.education_list.count() == 1
+        assert window.skills_summary_view.skill_list.count() >= 1
+    finally:
+        window.close()

--- a/tests/unit/test_skill_service.py
+++ b/tests/unit/test_skill_service.py
@@ -1,0 +1,64 @@
+"""Unit tests for the SkillService."""
+
+import pytest
+
+from adaptive_resume.services.profile_service import ProfileService
+from adaptive_resume.services.skill_service import (
+    SkillService,
+    SkillNotFoundError,
+    SkillValidationError,
+)
+
+
+def test_create_list_and_update_skill(session):
+    profile_service = ProfileService(session)
+    profile = profile_service.create_profile(
+        first_name="Sam",
+        last_name="Taylor",
+        email="sam.taylor@example.com",
+    )
+
+    service = SkillService(session)
+    skill = service.create_skill(
+        profile_id=profile.id,
+        skill_name="Python",
+        category="Programming Languages",
+        proficiency_level="Expert",
+        years_experience=7.5,
+    )
+
+    assert skill.id is not None
+    assert skill.proficiency_level == "Expert"
+
+    skills = service.list_skills_for_profile(profile.id)
+    assert len(skills) == 1
+
+    updated = service.update_skill(skill.id, proficiency_level="Advanced", years_experience=8.0)
+    assert updated.proficiency_level == "Advanced"
+    assert float(updated.years_experience) == 8.0
+
+    service.reorder_skills(profile.id, [skill.id])
+
+    service.delete_skill(skill.id)
+    with pytest.raises(SkillNotFoundError):
+        service.get_skill_by_id(skill.id)
+
+
+def test_create_skill_validates_input(session):
+    profile_service = ProfileService(session)
+    profile = profile_service.create_profile(
+        first_name="Sky",
+        last_name="Wong",
+        email="sky.wong@example.com",
+    )
+
+    service = SkillService(session)
+
+    with pytest.raises(SkillValidationError):
+        service.create_skill(profile.id, skill_name="", proficiency_level="Expert")
+
+    with pytest.raises(SkillValidationError):
+        service.create_skill(profile.id, skill_name="Leadership", proficiency_level="Master")
+
+    with pytest.raises(SkillValidationError):
+        service.create_skill(profile.id, skill_name="Leadership", years_experience=-1)


### PR DESCRIPTION
## Summary
- compare dialog exec results against Qt acceptance codes using their integer values
- drop the PyQt-specific type ignore markers from the GUI dialog helpers

## Testing
- `PYTHONPATH=src pytest -o addopts= -q`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69109483cf60832dbda92d34e15c2767)