### PR TITLE
Fix AttributeError in skill edit dialog

### DIFF
--- a/src/adaptive_resume/gui/screens/skills_screen.py
+++ b/src/adaptive_resume/gui/screens/skills_screen.py
@@ -83,7 +83,7 @@ class SkillsScreen(BaseScreen):
 
     def get_selected_skill_id(self) -> Optional[int]:
         """Get the ID of the currently selected skill."""
-        current_item = self.skills_panel.skills_list.currentItem()
+        current_item = self.skills_panel.skill_list.currentItem()
         if current_item is None:
             return None
         return int(current_item.data(Qt.ItemDataRole.UserRole))


### PR DESCRIPTION
Fixed the AttributeError that occurred when trying to open the Edit dialog for a skill.

### Changes
- Changed `skills_list` to `skill_list` in `SkillsScreen.get_selected_skill_id()` to match the actual attribute name in `SkillsPanel`

Fixes #8

Generated with [Claude Code](https://claude.ai/code)